### PR TITLE
Add nodeAffinity local storage PVs

### DIFF
--- a/tasks/volume.yml
+++ b/tasks/volume.yml
@@ -101,6 +101,13 @@
             }}
         hostPath:
           path: "{{ settings.mountpoint }}"
+        nodeAffinity:
+          required:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values: ["{{ openshift_hostname }}"]
         accessModes:
           - ReadWriteOnce
           - ReadWriteMany


### PR DESCRIPTION
With Kubernetes 1.10 which comes with OpenShift 3.10, the
PersistentVolume object now allows to define `nodeAffinity` allowing to
control on which host this PV can be made available.

Pods which are bound to a PV with `nodeAffinity` set, will be forced to
be scheduled acording to its nodeSelectors. This comes into play for
logging Elasticsearch. So far we used node labes set via
`openshift_node_labesl` as this is no longer available, using PV
`nodeAffinity` allows us to control that the Elasticsearch pod will be
scheduled on the node containing its local storage.