### PR TITLE
Remove usage of openshift_hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ containers as `hostPath` persistent storage objects.
 
 * `appuio_openshift_localstorage_override`: Override values for all volumes.
 
+* `appuio_openshift_localstorage_node_name`: The OpenShift node name. Defaults
+  to `inventory_hostname`.  It must be set to the same value as
+  `openshift_kubelet_name_override`. For AWS environments, this usually is
+  `ec2_private_dns_name`.
 
 ## Example playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,5 @@ appuio_openshift_localstorage_override: {}
 
 # Volumes
 appuio_openshift_localstorage: {}
+
+appuio_openshift_localstorage_node_name: "{{ inventory_hostname }}"

--- a/tasks/volume.yml
+++ b/tasks/volume.yml
@@ -14,7 +14,7 @@
         selevel="s0",
         pv_create=True,
         pv_labels=dict(
-          hostname=(openshift_hostname | mandatory),
+          hostname=appuio_openshift_localstorage_node_name,
         ),
         pv_storage_class="local",
         pv_reclaim_policy="Retain",
@@ -107,7 +107,7 @@
               - matchExpressions:
                   - key: kubernetes.io/hostname
                     operator: In
-                    values: ["{{ openshift_hostname }}"]
+                    values: ["{{ appuio_openshift_localstorage_node_name }}"]
         accessModes:
           - ReadWriteOnce
           - ReadWriteMany


### PR DESCRIPTION
With OpenShfit v3.10, the variable `openshift_hostname` got removed.