### PR TITLE
Make need for OpenShift node name explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ containers as `hostPath` persistent storage objects.
 
 * `appuio_openshift_localstorage_override`: Override values for all volumes.
 
-* `appuio_openshift_localstorage_node_name`: The OpenShift node name. Defaults
-  to `inventory_hostname`.  It must be set to the same value as
+* `appuio_openshift_localstorage_openshift_node_name`: OpenShift node name.
+  Defaults to `inventory_hostname`. Must be set to the same value as
   `openshift_kubelet_name_override`. For AWS environments, this usually is
   `ec2_private_dns_name`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,9 @@ appuio_openshift_localstorage_mountpoint_parent: /data
 appuio_openshift_localstorage_defaults: {}
 appuio_openshift_localstorage_override: {}
 
+# Per node
+appuio_openshift_localstorage_openshift_node_name: >-
+  {{ appuio_openshift_localstorage_node_name | default(inventory_hostname) }}
+
 # Volumes
 appuio_openshift_localstorage: {}
-
-appuio_openshift_localstorage_node_name: "{{ inventory_hostname }}"

--- a/tasks/volume.yml
+++ b/tasks/volume.yml
@@ -14,7 +14,7 @@
         selevel="s0",
         pv_create=True,
         pv_labels=dict(
-          hostname=appuio_openshift_localstorage_node_name,
+          hostname=appuio_openshift_localstorage_openshift_node_name,
         ),
         pv_storage_class="local",
         pv_reclaim_policy="Retain",
@@ -107,7 +107,7 @@
               - matchExpressions:
                   - key: kubernetes.io/hostname
                     operator: In
-                    values: ["{{ appuio_openshift_localstorage_node_name }}"]
+                    values: ["{{ appuio_openshift_localstorage_openshift_node_name }}"]
         accessModes:
           - ReadWriteOnce
           - ReadWriteMany


### PR DESCRIPTION
Commit 44c0b99 added a dedicated variable to configure the OpenShift
node name. Unfortunately it wasn't clear whether the host name or the
name of the node in OpenShift is necessary. With this change the
variable is renamed to explicitly call out the need for the OpenShift
node name.