### PR TITLE
Hardened default mount options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,14 @@
 appuio_openshift_localstorage_mountpoint_parent: /data
 appuio_openshift_localstorage_defaults: {}
 appuio_openshift_localstorage_override: {}
+appuio_openshift_localstorage_mountopts:
+  - x-systemd.after=fcoe.service
+  - x-systemd.after=iscsi.service
+  - x-systemd.after=iscsid.service
+  - x-systemd.after=lvm2-activation.service
+  - x-systemd.after=lvm2-lvmetad.service
+  - x-systemd.after=multipathd.service
+  - x-systemd.requires=systemd-udev-settle.service
 
 # Volumes
 appuio_openshift_localstorage: {}

--- a/tasks/volume.yml
+++ b/tasks/volume.yml
@@ -4,7 +4,7 @@
       {{
       dict(
         mountpoint=(appuio_openshift_localstorage_mountpoint_parent ~ '/' ~ item.key),
-        mountopts="defaults",
+        mountopts=((['defaults'] + appuio_openshift_localstorage_mountopts) | unique | join(',')),
         owner="root",
         group="root",
         mode="0770",


### PR DESCRIPTION
Depending on how storage gets attached to a system, mount points can
fail due to the underlying infrastructure not being ready. This commit
adds an extended lists of potential systemd units which should ready for
mounts to be successful.

As not all of those units will be available on every system, `After` is
used to prevent failures if one of them is missing.