### PR TITLE
Implement support for LUKS-backed localstorage volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ containers as `hostPath` persistent storage objects.
   * `pv_annotations`: Dictionary with additional annotations for PV object
   * `pv_storage_class`: Storage class name
   * `pv_reclaim_policy`: Reclaim policy
+  * `encrypted`: Whether to setup the localstorage volume on a LUKS-on-LVM volume.
+     Encrypted volumes are skipped if the environment variable `ANSIBLE_OPENSHIFT_LOCALSTORAGE_<node>` is not set.
+     Otherwise, the value of that variable is used as the LUKS key for all volumes on `<node>`.
+     `<node>` is constructed as `inventory_hostname.split('.')[0]`, as bash doesn't allow dots in environment variable names.
+  * `luks_key_url`: Used for informational purposes only. Can hold an arbitrary string value.
 
   Additionally permissions for the mountpoint directory can be specified. See
   [Ansible file module](https://docs.ansible.com/ansible/latest/file_module.html)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,4 +7,4 @@ galaxy_info:
 
 dependencies:
   - src: git+https://github.com/appuio/ansible-module-openshift.git
-    version: v1.3.4
+    version: v1.5.0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Configure OpenShift persistent volumes
   company: VSHN AG
   license: BSD
-  min_ansible_version: 2.3
+  min_ansible_version: 2.8
 
 dependencies:
   - src: git+https://github.com/appuio/ansible-module-openshift.git

--- a/tasks/cryptvol-post.yml
+++ b/tasks/cryptvol-post.yml
@@ -1,0 +1,13 @@
+---
+- name: Unmount keyfile LUKS volume
+  mount:
+    name: "/mnt/{{ l_keycrypt }}"
+    state: absent
+
+- name: Close keyfile LUKS volume
+  luks_device:
+    name: "{{ l_keycrypt }}"
+    state: closed
+
+- name: Remove keyfile loop device
+  shell: "losetup -d {{ l_loopdev }}"

--- a/tasks/cryptvol-pre.yml
+++ b/tasks/cryptvol-pre.yml
@@ -1,0 +1,77 @@
+---
+- set_fact:
+    l_luks_file: /etc/openshift-localstorage-key.luks
+    l_keycrypt: crypt_openshift_localstorage_key
+
+- set_fact:
+    l_volkey_mount: "/mnt/{{ l_keycrypt }}"
+
+- set_fact:
+    l_volkey_path: "{{ l_volkey_mount }}/keyfile"
+
+- name: Create file for LUKS container if it doesn't exist
+  copy:
+    content: ""
+    dest: "{{ l_luks_file }}"
+    force: no
+    owner: root
+    group: root
+    mode: 0600
+  register: r_luksfile_copy
+
+- name: Resize file for LUKS container if it's new
+  when: r_luksfile_copy.changed
+  shell: "dd if=/dev/zero of={{ l_luks_file }} count=4 bs=1M"
+
+- name: Create loop device for keyfile LUKS container
+  shell: "losetup --show -f {{ l_luks_file }}"
+  register: r_losetup
+
+- set_fact:
+    l_loopdev: "{{ r_losetup.stdout|trim }}"
+
+- name: "Create tempfile for user-provided LUKS key"
+  tempfile:
+    state: file
+    suffix: .key
+  register: r_keyfile
+
+- name: "Store user-provided LUKS key in tempfile"
+  copy:
+    dest: "{{ r_keyfile.path }}"
+    content: "{{ l_luks_key|trim }}"
+
+- name: Create LUKS container for keyfile
+  luks_device:
+    device: "{{ l_loopdev }}"
+    state: opened
+    name: "{{ l_keycrypt }}"
+    keyfile: "{{ r_keyfile.path }}"
+
+- name: Remove tempfile containing user-provided LUKS key
+  file:
+    path: "{{ r_keyfile.path }}"
+    state: absent
+
+- name: Format LUKS container for keyfile
+  filesystem:
+    fstype: ext4
+    dev: "/dev/mapper/{{ l_keycrypt }}"
+
+- name: Mount LUKS container for keyfile
+  mount:
+    name: "{{ l_volkey_mount }}"
+    src: "/dev/mapper/{{ l_keycrypt }}"
+    fstype: ext4
+    state: mounted
+    opts: "nofail"
+
+- name: Create keyfile in LUKS container
+  copy:
+    content: "{{ l_luks_key|trim }}"
+    dest: "{{ l_volkey_path }}"
+    force: no
+    owner: root
+    group: root
+    mode: 0600
+  register: r_volkey

--- a/tasks/cryptvol.yml
+++ b/tasks/cryptvol.yml
@@ -26,3 +26,6 @@
 
 - set_fact:
     dev: "{{ '/dev/mapper/' ~ crypt_name }}"
+
+- set_fact:
+    r_crypt_devices: "{{ (r_crypt_devices|default([])) + [crypt_name] }}"

--- a/tasks/cryptvol.yml
+++ b/tasks/cryptvol.yml
@@ -1,0 +1,34 @@
+---
+- name: "{{ item.key }}: Create and open LUKS device for LV"
+  luks_device:
+    device: "{{ dev }}"
+    state: "opened"
+    name: "{{ crypt_name }}"
+    keyfile: "{{ r_keyfile.path }}"
+
+- name: "{{ item.key }}: Remove tempfile containing LUKS key"
+  file:
+    path: "{{ r_keyfile.path }}"
+    state: "absent"
+  when: r_keyfile.path is defined
+
+- name: "{{ item.key }}: Determine LUKS device UUID"
+  command: "/sbin/blkid -c /dev/null -o value -s UUID {{ dev | quote }}"
+  changed_when: false
+  register: cryptblkid
+
+- name: "{{ item.key }}: Add LUKS device in crypttab"
+  crypttab:
+    name: "{{ crypt_name }}"
+    state: present
+    opts: luks,noauto
+    backing_device: "UUID={{ cryptblkid.stdout|trim }}"
+
+- name: Reload systemd to ensure crypttab changes are picked up
+  command: systemctl daemon-reload
+
+- name: Start systemd-cryptsetup for volume
+  command: "systemctl start systemd-cryptsetup@{{ crypt_name }}.service"
+
+- set_fact:
+    dev: "{{ '/dev/mapper/' ~ crypt_name }}"

--- a/tasks/cryptvol.yml
+++ b/tasks/cryptvol.yml
@@ -6,12 +6,6 @@
     name: "{{ crypt_name }}"
     keyfile: "{{ r_keyfile.path }}"
 
-- name: "{{ item.key }}: Remove tempfile containing LUKS key"
-  file:
-    path: "{{ r_keyfile.path }}"
-    state: "absent"
-  when: r_keyfile.path is defined
-
 - name: "{{ item.key }}: Determine LUKS device UUID"
   command: "/sbin/blkid -c /dev/null -o value -s UUID {{ dev | quote }}"
   changed_when: false

--- a/tasks/cryptvol.yml
+++ b/tasks/cryptvol.yml
@@ -4,7 +4,7 @@
     device: "{{ dev }}"
     state: "opened"
     name: "{{ crypt_name }}"
-    keyfile: "{{ r_keyfile.path }}"
+    keyfile: "{{ l_volkey_path }}"
 
 - name: "{{ item.key }}: Determine LUKS device UUID"
   command: "/sbin/blkid -c /dev/null -o value -s UUID {{ dev | quote }}"
@@ -16,6 +16,7 @@
     name: "{{ crypt_name }}"
     state: present
     opts: luks,noauto
+    password: "{{ l_volkey_path }}"
     backing_device: "UUID={{ cryptblkid.stdout|trim }}"
 
 - name: Reload systemd to ensure crypttab changes are picked up

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,26 +20,13 @@
     l_luks_key: "{{ lookup('env', 'ANSIBLE_OPENSHIFT_LOCALSTORAGE_LUKS_KEY_' ~ l_node) | default('', True) }}"
 
 - when: l_luks_key != ""
-  block:
-    - name: "Create tempfile for LUKS key"
-      tempfile:
-        state: file
-        suffix: .key
-      register: r_keyfile
-
-    - name: "Store LUKS key in tempfile"
-      copy:
-        dest: "{{ r_keyfile.path }}"
-        content: "{{ l_luks_key|trim }}"
+  include_tasks: cryptvol-pre.yml
 
 - include_tasks: volume.yml
   with_dict: '{{ appuio_openshift_localstorage }}'
 
-- name: "Remove tempfile containing LUKS key"
-  file:
-    path: "{{ r_keyfile.path }}"
-    state: "absent"
-  when: r_keyfile.path is defined
+- when: l_luks_key != ""
+  include_tasks: cryptvol-post.yml
 
 - name: "Install /usr/local/sbin/start-encrypted-devices"
   when: (r_crypt_devices | default([])) != []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,5 +13,30 @@
     setype: default_t
     selevel: s0
 
+- set_fact:
+    l_node: "{{ inventory_hostname.split('.')[0] }}"
+
+- set_fact:
+    l_luks_key: "{{ lookup('env', 'ANSIBLE_OPENSHIFT_LOCALSTORAGE_LUKS_KEY_' ~ l_node) | default('', True) }}"
+
+- when: l_luks_key != ""
+  block:
+    - name: "Create tempfile for LUKS key"
+      tempfile:
+        state: file
+        suffix: .key
+      register: r_keyfile
+
+    - name: "Store LUKS key in tempfile"
+      copy:
+        dest: "{{ r_keyfile.path }}"
+        content: "{{ l_luks_key|trim }}"
+
 - include_tasks: volume.yml
   with_dict: '{{ appuio_openshift_localstorage }}'
+
+- name: "Remove tempfile containing LUKS key"
+  file:
+    path: "{{ r_keyfile.path }}"
+    state: "absent"
+  when: r_keyfile.path is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,3 +40,14 @@
     path: "{{ r_keyfile.path }}"
     state: "absent"
   when: r_keyfile.path is defined
+
+- name: "Install /usr/local/sbin/start-encrypted-devices"
+  when: (r_crypt_devices | default([])) != []
+  vars:
+    crypt_devices: "{{ r_crypt_devices }}"
+  template:
+    dest: /usr/local/sbin/start-encrypted-devices
+    src: start-encrypted-devices.j2
+    owner: root
+    group: root
+    mode: '0755'

--- a/tasks/volume.yml
+++ b/tasks/volume.yml
@@ -92,6 +92,8 @@
 
     - when: "settings.pv_create | default(false)"
       name: Create OpenShift PV object
+      vars:
+        l_pv_storage_class: "{{ (settings.encrypted and settings.pv_storage_class=='local') | ternary('local-luks', settings.pv_storage_class) }}"
       run_once: true
       delegate_to: "{{ groups.masters.0 | mandatory }}"
       openshift_resource:
@@ -124,7 +126,7 @@
             accessModes:
               - ReadWriteOnce
               - ReadWriteMany
-            storageClassName: "{{ settings.pv_storage_class }}"
+            storageClassName: "{{ l_pv_storage_class }}"
             persistentVolumeReclaimPolicy: "{{ settings.pv_reclaim_policy }}"
       tags:
         - openshift-pv

--- a/tasks/volume.yml
+++ b/tasks/volume.yml
@@ -12,6 +12,8 @@
         serole="object_r",
         setype="svirt_sandbox_file_t",
         selevel="s0",
+        encrypted=False,
+        luks_key_url='N/A',
         pv_create=True,
         pv_labels=dict(
           hostname=appuio_openshift_localstorage_openshift_node_name,
@@ -40,77 +42,89 @@
 
 - set_fact:
     dev: "{{ '/dev/' ~ settings.lvm_vg ~ '/' ~ item.key }}"
+    crypt_name: "{{ 'crypt_' ~ settings.lvm_vg ~ '_' ~ (item.key|replace('-', '_')) }}"
 
-- name: "{{ item.key }}: Create backing filesystem"
-  filesystem:
-    fstype: xfs
-    dev: "{{ dev }}"
-    opts: "-i size=512 -n size=8192"
-    resizefs: true
+- name: "Warn if no LUKS key provided"
+  when: l_luks_key == ""
+  debug:
+    msg: "Skipping localstorage volume {{ item.key }} on node {{ inventory_hostname }}. Provide LUKS key in environment variable ANSIBLE_OPENSHIFT_LOCALSTORAGE_LUKS_KEY_{{ l_node }}. Key can be found at {{ settings.luks_key_url }}."
 
-- name: "{{ item.key }}: Determine filesystem UUID"
-  command: "/sbin/blkid -c /dev/null -o value -s UUID {{ dev | quote }}"
-  changed_when: false
-  register: blkid
+- when: not settings.encrypted or l_luks_key != ""
+  block:
+    - name: "{{ item.key }}: Set up LUKS on logical volume"
+      when: settings.encrypted and l_luks_key != ""
+      include_tasks: cryptvol.yml
 
-- set_fact:
-    fsuuid: "{{ blkid.stdout | trim }}"
+    - name: "{{ item.key }}: Create backing filesystem"
+      filesystem:
+        fstype: xfs
+        dev: "{{ dev }}"
+        opts: "-i size=512 -n size=8192"
+        resizefs: true
 
-- name: "{{ item.key }}: Mount backing filesystem"
-  mount:
-    name: "{{ settings.mountpoint }}"
-    src: "UUID={{ fsuuid }}"
-    fstype: xfs
-    opts: "{{ settings.mountopts }}"
-    state: mounted
+    - name: "{{ item.key }}: Determine filesystem UUID"
+      command: "/sbin/blkid -c /dev/null -o value -s UUID {{ dev | quote }}"
+      changed_when: false
+      register: blkid
 
-- name: "{{ item.key }}: Set backing filesystem permissions"
-  file:
-    path: "{{ settings.mountpoint }}"
-    state: directory
-    owner: "{{ settings.owner }}"
-    group: "{{ settings.group }}"
-    mode: "{{ settings.mode }}"
-    seuser: "{{ settings.seuser }}"
-    serole: "{{ settings.serole }}"
-    setype: "{{ settings.setype }}"
-    selevel: "{{ settings.selevel }}"
+    - set_fact:
+        fsuuid: "{{ blkid.stdout | trim }}"
 
-- when: "settings.pv_create | default(false)"
-  name: Create OpenShift PV object
-  run_once: true
-  delegate_to: "{{ groups.masters.0 | mandatory }}"
-  openshift_resource:
-    namespace: default
-    patch:
-      apiVersion: v1
-      kind: PersistentVolume
-      metadata:
-        name: "{{ item.key }}"
-        labels: "{{ settings.pv_labels }}"
-        annotations: "{{ settings.pv_annotations }}"
-      spec:
-        capacity:
-          storage: >-
-            {{
-            (
-              ((settings.size | int) / (1024.0 * 1024)) |
-              round(precision=0, method='floor') | int
-            ) ~ "Mi"
-            }}
-        hostPath:
-          path: "{{ settings.mountpoint }}"
-        nodeAffinity:
-          required:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values: ["{{ appuio_openshift_localstorage_openshift_node_name }}"]
-        accessModes:
-          - ReadWriteOnce
-          - ReadWriteMany
-        storageClassName: "{{ settings.pv_storage_class }}"
-        persistentVolumeReclaimPolicy: "{{ settings.pv_reclaim_policy }}"
-  tags:
-    - openshift-pv
+    - name: "{{ item.key }}: Mount backing filesystem"
+      mount:
+        name: "{{ settings.mountpoint }}"
+        src: "UUID={{ fsuuid }}"
+        fstype: xfs
+        opts: "{{ settings.mountopts }}"
+        state: mounted
+
+    - name: "{{ item.key }}: Set backing filesystem permissions"
+      file:
+        path: "{{ settings.mountpoint }}"
+        state: directory
+        owner: "{{ settings.owner }}"
+        group: "{{ settings.group }}"
+        mode: "{{ settings.mode }}"
+        seuser: "{{ settings.seuser }}"
+        serole: "{{ settings.serole }}"
+        setype: "{{ settings.setype }}"
+        selevel: "{{ settings.selevel }}"
+
+    - when: "settings.pv_create | default(false)"
+      name: Create OpenShift PV object
+      run_once: true
+      delegate_to: "{{ groups.masters.0 | mandatory }}"
+      openshift_resource:
+        namespace: default
+        patch:
+          apiVersion: v1
+          kind: PersistentVolume
+          metadata:
+            name: "{{ item.key }}"
+            labels: "{{ settings.pv_labels }}"
+            annotations: "{{ settings.pv_annotations }}"
+          spec:
+            capacity:
+              storage: >-
+                {{
+                (
+                  ((settings.size | int) / (1024.0 * 1024)) |
+                  round(precision=0, method='floor') | int
+                ) ~ "Mi"
+                }}
+            hostPath:
+              path: "{{ settings.mountpoint }}"
+            nodeAffinity:
+              required:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/hostname
+                        operator: In
+                        values: ["{{ appuio_openshift_localstorage_openshift_node_name }}"]
+            accessModes:
+              - ReadWriteOnce
+              - ReadWriteMany
+            storageClassName: "{{ settings.pv_storage_class }}"
+            persistentVolumeReclaimPolicy: "{{ settings.pv_reclaim_policy }}"
+      tags:
+        - openshift-pv

--- a/tasks/volume.yml
+++ b/tasks/volume.yml
@@ -5,6 +5,7 @@
       dict(
         mountpoint=(appuio_openshift_localstorage_mountpoint_parent ~ '/' ~ item.key),
         mountopts=((['defaults'] + appuio_openshift_localstorage_mountopts) | unique | join(',')),
+        crypt_mountopts=(['nofail'] | join(',')),
         owner="root",
         group="root",
         mode="0770",
@@ -71,11 +72,18 @@
         fsuuid: "{{ blkid.stdout | trim }}"
 
     - name: "{{ item.key }}: Mount backing filesystem"
+      vars:
+        mountopts: >-
+          {%- if (settings.encrypted | default(false)) -%}
+            {{ [settings.mountopts, settings.crypt_mountopts]|join(",") }}
+          {%- else -%}
+            {{ settings.mountopts }}
+          {%- endif -%}
       mount:
         name: "{{ settings.mountpoint }}"
         src: "UUID={{ fsuuid }}"
         fstype: xfs
-        opts: "{{ settings.mountopts }}"
+        opts: "{{ mountopts }}"
         state: mounted
 
     - name: "{{ item.key }}: Set backing filesystem permissions"

--- a/templates/start-encrypted-devices.j2
+++ b/templates/start-encrypted-devices.j2
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Managed by Ansible role {{ ansible_role_name }}
+
+set -e
+
+if [ "$1" = "status" ]; then
+{% for dev in crypt_devices %}
+  systemctl is-active --quiet systemd-cryptsetup@{{ dev }}.service || exit 1
+{% endfor %}
+  exit 0
+fi
+
+{% for dev in crypt_devices %}
+systemctl start systemd-cryptsetup@{{ dev }}.service
+{% endfor %}
+mount -a
+echo OK
+
+exit 0
+

--- a/templates/start-encrypted-devices.j2
+++ b/templates/start-encrypted-devices.j2
@@ -3,6 +3,18 @@
 
 set -e
 
+unlock_keyfile() {
+  mkdir -p {{ l_volkey_mount }}
+  cryptsetup open {{ l_luks_file }} {{ l_keycrypt }}
+  mount /dev/mapper/{{ l_keycrypt }} {{ l_volkey_mount }}
+}
+
+lock_keyfile() {
+  umount {{ l_volkey_mount }}
+  cryptsetup close {{ l_keycrypt }}
+  rmdir {{ l_volkey_mount }}
+}
+
 if [ "$1" = "status" ]; then
 {% for dev in crypt_devices %}
   systemctl is-active --quiet systemd-cryptsetup@{{ dev }}.service || exit 1
@@ -10,11 +22,14 @@ if [ "$1" = "status" ]; then
   exit 0
 fi
 
+unlock_keyfile
 {% for dev in crypt_devices %}
 systemctl start systemd-cryptsetup@{{ dev }}.service
 {% endfor %}
-mount -a
+lock_keyfile
+
 echo OK
 
 exit 0
 
+# vim: ts=2 et sw=2


### PR DESCRIPTION
An encryption key can be specified per node in environment variable `ANSIBLE_OPENSHIFT_LOCALSTORAGE_<node_name>`, where `<node_name>` is constructed as `inventory_hostname.split('.')[0]`.

New settings fields `encrypted` (defaults to False, if unset) and `luks_key_url` (defaults to 'N/A' if unset) are introduced.
* `encrypted` controls whether the volume should use LUKS on LVM.
* `luks_key_url` can be used to point the user to a password safe entry where the key can be found. Omitting `luks_key_url` has no impact on the actual work done.