### PR TITLE
Ensure atomic-openshift-node is started only after LUKS volumes are unlocked

### DIFF
--- a/tasks/cryptvol-post.yml
+++ b/tasks/cryptvol-post.yml
@@ -11,3 +11,44 @@
 
 - name: Remove keyfile loop device
   shell: "losetup -d {{ l_loopdev }}"
+
+- when: (r_crypt_devices | default([])) != []
+  block:
+    - name: "Install /usr/local/sbin/start-encrypted-devices"
+      vars:
+        crypt_devices: "{{ r_crypt_devices }}"
+      template:
+        dest: /usr/local/sbin/start-encrypted-devices
+        src: start-encrypted-devices.j2
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Ensure atomic-openshift-node is not started automatically
+      service:
+        name: atomic-openshift-node
+        enabled: false
+
+    - name: Ensure systemd atomic-openshift-node.service.d exists
+      file:
+        path: /etc/systemd/system/atomic-openshift-node.service.d
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+
+    - name: Setup dependencies for atomic-openshift-node
+      vars:
+        dependencies: >-
+          {%- for volume in r_crypt_devices -%}
+          systemd-cryptsetup@{{ volume }}.service
+          {% endfor -%}
+      template:
+        dest: /etc/systemd/system/atomic-openshift-node.service.d/appuio-encrypted-localstorage.conf
+        src: atomic-openshift-node-unit-deps.j2
+        owner: root
+        group: root
+        mode: 0644
+
+    - name: Reload systemd to ensure config changes are picked up
+      command: systemctl daemon-reload

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,13 +28,3 @@
 - when: l_luks_key != ""
   include_tasks: cryptvol-post.yml
 
-- name: "Install /usr/local/sbin/start-encrypted-devices"
-  when: (r_crypt_devices | default([])) != []
-  vars:
-    crypt_devices: "{{ r_crypt_devices }}"
-  template:
-    dest: /usr/local/sbin/start-encrypted-devices
-    src: start-encrypted-devices.j2
-    owner: root
-    group: root
-    mode: '0755'

--- a/templates/atomic-openshift-node-unit-deps.j2
+++ b/templates/atomic-openshift-node-unit-deps.j2
@@ -1,0 +1,3 @@
+[Unit]
+Requires={{ dependencies }}
+After={{ dependencies }}

--- a/templates/start-encrypted-devices.j2
+++ b/templates/start-encrypted-devices.j2
@@ -28,6 +28,9 @@ systemctl start systemd-cryptsetup@{{ dev }}.service
 {% endfor %}
 lock_keyfile
 
+# Start Kubelet after unlocking localstorage volumes
+systemctl start atomic-openshift-node.service
+
 echo OK
 
 exit 0


### PR DESCRIPTION
This addresses the situation where a node is unexpectedly rebooted, and pods using encrypted localstorage volumes could get scheduled on the node before the operator has a chance to unlock the encrypted volumes.

Note: this change also requires a little adjustment of the internal maintenance procedure at VSHN.